### PR TITLE
Fix critical security and operational issues

### DIFF
--- a/ISSUE-LOG.md
+++ b/ISSUE-LOG.md
@@ -1,0 +1,45 @@
+# Issue Log
+
+Remaining issues identified during code review that do not block deployment or core functionality but should be addressed.
+
+## Code Quality
+
+### Multiple pino logger instances
+- **Files**: `src/index.ts`, `src/web/middleware/request-logger.ts`, `src/web/controllers/auth.ts`
+- **Issue**: Each file creates its own `pino({ level: 'info' })` instance. Should share a single configured logger (e.g., export from a `src/logger.ts` module).
+
+### Database pool not configured
+- **File**: `src/services/db.ts`
+- **Issue**: `postgres(config.databaseUrl)` uses default pool settings. On a 256MB Fly.io VM, should explicitly set `max`, `idle_timeout`, and `connect_timeout`.
+
+### Deprecated docker-compose version key
+- **File**: `docker-compose.yml`
+- **Issue**: `version: '3.8'` is deprecated in Docker Compose v2+. Remove the line to suppress warnings.
+
+## Spec Compliance
+
+### Missing action-logger middleware
+- **File**: `src/web/app.ts`
+- **Issue**: The spec requires an action-logger middleware that automatically logs `user_action_events` for every authenticated request. Currently, action logging is done manually in individual controllers, so page views like `GET /dashboard` and `GET /profile` are never logged.
+
+### Profile update returns inline HTML instead of EJS partials
+- **File**: `src/web/controllers/profile.ts` (lines 54, 72)
+- **Issue**: Returns raw `c.html(...)` strings instead of rendering the `profile-feedback.ejs` partial. Should use `renderView` or `ejs.renderFile` for consistency.
+
+### Email enumeration via /api/check-email
+- **File**: `src/web/middleware/csrf.ts` (line 6), `src/web/controllers/auth.ts` (lines 158-171)
+- **Issue**: The `/api/check-email` endpoint is CSRF-exempt and reveals whether an email is registered. While it is rate-limited (20 req/min), any cross-origin site can probe it. Consider requiring CSRF tokens for this endpoint (pass via HTMX headers) or returning a generic response.
+
+## Minor
+
+### Login failure reason ordering
+- **File**: `src/web/controllers/auth.ts` (lines 46-48)
+- **Issue**: If the password is invalid AND the user is unverified, `failureReason` is set to `not_verified` instead of `invalid_password`. The priority ordering is debatable but may mask brute-force attempts against unverified accounts.
+
+### Seed script redundant UPDATE
+- **File**: `scripts/seed.ts` (lines 15-25)
+- **Issue**: The `INSERT ... ON CONFLICT DO NOTHING` is immediately followed by an unconditional `UPDATE` on the same email, making the conflict handling pointless. Should use `ON CONFLICT DO UPDATE` or remove the separate UPDATE.
+
+### SESSION_SECRET defaults to hardcoded value in development
+- **File**: `src/config.ts` (line 11)
+- **Issue**: Falls back to `'dev-secret-change-me'` when `SESSION_SECRET` is unset and `NODE_ENV` is not `production`. Low risk since production enforces the env var, but could be a problem if `NODE_ENV` is misconfigured.

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -63,7 +63,7 @@ export const userService = {
   },
 
   async findByVerificationToken(tokenHash: string): Promise<User | null> {
-    const rows = await sql`SELECT * FROM users WHERE verification_token = ${tokenHash} AND verification_token_expires_at > NOW()`;
+    const rows = await sql`SELECT * FROM users WHERE verification_token = ${tokenHash} AND verification_token_expires_at > NOW() AND is_verified = FALSE`;
     if (rows.length === 0) return null;
     return mapUser(rows[0] as Record<string, unknown>);
   },

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -18,9 +18,12 @@ type Variables = {
   sessionId: string | null;
   sessionCookie: string | undefined;
   user: User | undefined;
+  parsedBody: Record<string, string | File> | undefined;
 };
 
 const app = new Hono<{ Variables: Variables }>();
+
+app.use('/public/*', serveStatic({ root: './' }));
 
 app.use('*', secureHeaders({
   contentSecurityPolicy: {
@@ -56,7 +59,5 @@ app.get('/dashboard', authGuard, dashboardController.index);
 app.get('/profile', authGuard, profileController.editForm);
 app.post('/profile', authGuard, profileController.update);
 app.post('/logout', authGuard, authController.logout);
-
-app.use('/public/*', serveStatic({ root: './' }));
 
 export { app };

--- a/src/web/controllers/auth.ts
+++ b/src/web/controllers/auth.ts
@@ -8,12 +8,9 @@ import { eventService } from '../../services/event-service.js';
 import { createSession, destroySession, destroyUserSessions } from '../middleware/session.js';
 import type { SessionData } from '../middleware/session.js';
 import { config } from '../../config.js';
+import { getClientIp } from '../utils/get-client-ip.js';
 
 const logger = pino({ level: 'info' });
-
-function getIp(c: Context): string {
-  return c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? '127.0.0.1';
-}
 
 function hashToken(token: string): string {
   return crypto.createHash('sha256').update(token).digest('hex');
@@ -27,10 +24,10 @@ export const authController = {
   },
 
   async login(c: Context): Promise<Response> {
-    const body = await c.req.parseBody();
+    const body = (c.get('parsedBody') as Record<string, string | File> | undefined) ?? await c.req.parseBody();
     const email = ((body['email'] as string) ?? '').trim().toLowerCase();
     const password = (body['password'] as string) ?? '';
-    const ip = getIp(c);
+    const ip = getClientIp(c);
     const userAgent = c.req.header('user-agent') ?? null;
 
     const user = await userService.findByEmail(email);
@@ -80,8 +77,8 @@ export const authController = {
   },
 
   async register(c: Context): Promise<Response> {
-    const body = await c.req.parseBody();
-    const ip = getIp(c);
+    const body = (c.get('parsedBody') as Record<string, string | File> | undefined) ?? await c.req.parseBody();
+    const ip = getClientIp(c);
     const email = ((body['email'] as string) ?? '').trim().toLowerCase();
     const displayName = ((body['displayName'] as string) ?? '').trim();
     const password = (body['password'] as string) ?? '';
@@ -143,7 +140,7 @@ export const authController = {
       sessionId: null,
       action: 'email_verified',
       resource: '/verify-email',
-      ipAddress: getIp(c),
+      ipAddress: getClientIp(c),
     });
 
     const session = c.get('session') as SessionData | undefined;
@@ -156,7 +153,7 @@ export const authController = {
   },
 
   async checkEmail(c: Context): Promise<Response> {
-    const body = await c.req.parseBody();
+    const body = (c.get('parsedBody') as Record<string, string | File> | undefined) ?? await c.req.parseBody();
     const email = ((body['email'] as string) ?? '').trim().toLowerCase();
 
     if (!email) {
@@ -175,10 +172,11 @@ export const authController = {
   },
 
   async forgotPassword(c: Context): Promise<Response> {
-    const body = await c.req.parseBody();
+    const body = (c.get('parsedBody') as Record<string, string | File> | undefined) ?? await c.req.parseBody();
     const email = ((body['email'] as string) ?? '').trim().toLowerCase();
 
-    const ip = getIp(c);
+    const start = Date.now();
+    const ip = getClientIp(c);
     const user = await userService.findByEmail(email);
     if (user && user.isVerified && !user.isLocked) {
       const { raw, hashed } = authService.generateToken();
@@ -196,6 +194,12 @@ export const authController = {
         resource: '/forgot-password',
         ipAddress: ip,
       });
+    }
+
+    const elapsed = Date.now() - start;
+    const minTime = 200 + Math.random() * 300;
+    if (elapsed < minTime) {
+      await new Promise(resolve => setTimeout(resolve, minTime - elapsed));
     }
 
     return renderView(c, 'forgot-password-sent', { title: 'Check Your Email' });
@@ -217,7 +221,7 @@ export const authController = {
   },
 
   async resetPassword(c: Context): Promise<Response> {
-    const body = await c.req.parseBody();
+    const body = (c.get('parsedBody') as Record<string, string | File> | undefined) ?? await c.req.parseBody();
     const token = (body['token'] as string) ?? '';
     const password = (body['password'] as string) ?? '';
     const confirmPassword = (body['confirmPassword'] as string) ?? '';
@@ -249,7 +253,7 @@ export const authController = {
       sessionId: null,
       action: 'password_reset_completed',
       resource: '/reset-password',
-      ipAddress: getIp(c),
+      ipAddress: getClientIp(c),
     });
 
     const session = c.get('session') as SessionData | undefined;

--- a/src/web/controllers/profile.ts
+++ b/src/web/controllers/profile.ts
@@ -4,6 +4,7 @@ import { userService } from '../../services/user-service.js';
 import { authService } from '../../services/auth-service.js';
 import { eventService } from '../../services/event-service.js';
 import type { User } from '../../services/user-service.js';
+import { getClientIp } from '../utils/get-client-ip.js';
 
 export const profileController = {
   async editForm(c: Context): Promise<Response> {
@@ -11,7 +12,7 @@ export const profileController = {
   },
 
   async update(c: Context): Promise<Response> {
-    const body = await c.req.parseBody();
+    const body = (c.get('parsedBody') as Record<string, string | File> | undefined) ?? await c.req.parseBody();
     const displayName = ((body['displayName'] as string) ?? '').trim();
     const currentPassword = (body['currentPassword'] as string) ?? '';
     const newPassword = (body['newPassword'] as string) ?? '';
@@ -59,7 +60,7 @@ export const profileController = {
       const updatedUser = await userService.findById(user.id);
       if (updatedUser) c.set('user', updatedUser);
 
-      const ip = c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? '127.0.0.1';
+      const ip = getClientIp(c);
       await eventService.logAction({
         userId: user.id,
         sessionId: c.get('sessionId') as string | null,

--- a/src/web/middleware/csrf.ts
+++ b/src/web/middleware/csrf.ts
@@ -23,8 +23,9 @@ export const csrfMiddleware = createMiddleware(async (c, next) => {
 
   if (c.req.method === 'POST' && !CSRF_EXEMPT_PATHS.has(c.req.path)) {
     const body = await c.req.parseBody();
+    c.set('parsedBody', body);
     const token = body['_csrf'] as string | undefined;
-    if (!token || token !== session.csrfToken) {
+    if (!token || !session.csrfToken || Buffer.byteLength(token) !== Buffer.byteLength(session.csrfToken) || !crypto.timingSafeEqual(Buffer.from(token), Buffer.from(session.csrfToken))) {
       return c.text('Invalid CSRF token', 403);
     }
   }

--- a/src/web/middleware/rate-limit.ts
+++ b/src/web/middleware/rate-limit.ts
@@ -12,7 +12,8 @@ setInterval(() => {
 
 export function rateLimit(maxRequests: number, windowMs: number) {
   return createMiddleware(async (c, next) => {
-    const ip = c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? '127.0.0.1';
+    const forwardedFor = c.req.header('x-forwarded-for');
+    const ip = forwardedFor ? forwardedFor.split(',').pop()!.trim() : (c.req.header('x-real-ip') ?? '127.0.0.1');
     const key = `${c.req.path}:${ip}`;
     const now = Date.now();
 

--- a/src/web/middleware/session.ts
+++ b/src/web/middleware/session.ts
@@ -3,6 +3,15 @@ import crypto from 'crypto';
 import { sql } from '../../services/db.js';
 import { config } from '../../config.js';
 
+// Purge expired sessions every 15 minutes
+setInterval(async () => {
+  try {
+    await sql`DELETE FROM sessions WHERE expire < NOW()`;
+  } catch {
+    // Silently ignore cleanup errors to avoid crashing the process
+  }
+}, 15 * 60 * 1000).unref();
+
 export interface SessionData {
   userId?: string;
   csrfToken?: string;

--- a/src/web/utils/get-client-ip.ts
+++ b/src/web/utils/get-client-ip.ts
@@ -1,0 +1,8 @@
+import type { Context } from 'hono';
+
+export function getClientIp(c: Context): string {
+  const forwardedFor = c.req.header('x-forwarded-for');
+  return forwardedFor
+    ? forwardedFor.split(',').pop()!.trim()
+    : (c.req.header('x-real-ip') ?? '127.0.0.1');
+}


### PR DESCRIPTION
## Summary

Eight targeted fixes for security vulnerabilities and operational gaps, plus a documented issue log for remaining non-critical items.

### Changes

1. **Constant-time CSRF token comparison** (`src/web/middleware/csrf.ts`) — replaced `===` with `crypto.timingSafeEqual` to prevent timing attacks.

2. **Rightmost IP from `x-forwarded-for`** (`src/web/middleware/rate-limit.ts`, `src/web/controllers/auth.ts`, `src/web/controllers/profile.ts`) — use only the last (proxy-appended) IP to prevent client-side spoofing. Extracted shared `getClientIp()` utility at `src/web/utils/get-client-ip.ts`.

3. **Forgot-password timing normalization** (`src/web/controllers/auth.ts`) — added a random 200-500ms floor so the response time is the same whether or not the user exists, preventing user-enumeration via timing side-channel.

4. **`is_verified = FALSE` guard on verification token lookup** (`src/services/user-service.ts`) — prevents re-verification of already-verified accounts.

5. **Expired session cleanup** (`src/web/middleware/session.ts`) — `setInterval` every 15 minutes deletes expired rows from the `sessions` table (`.unref()` to avoid blocking shutdown).

6. **Static file serving before middleware** (`src/web/app.ts`) — moved `serveStatic('/public/*')` ahead of session/CSRF/logger middleware so static assets skip unnecessary processing.

7. **Parsed body reuse across CSRF + controllers** (`src/web/middleware/csrf.ts`, `src/web/app.ts`, controllers) — CSRF middleware now stores the parsed body via `c.set('parsedBody', body)`. Controllers read from context first, falling back to `parseBody()`. Added `parsedBody` to the `Variables` type.

8. **`ISSUE-LOG.md`** — documents remaining non-critical issues (multiple logger instances, unconfigured DB pool, deprecated compose key, missing action-logger middleware, email enumeration via `/api/check-email`, etc.).

Note: `package-lock.json` was already present in the repo; `npm install` produced no diff.

## Review & Testing Checklist for Human

- [ ] Verify CSRF token validation still works end-to-end (login, register, profile update, forgot/reset password forms)
- [ ] Confirm rate limiting uses the correct IP behind Fly.io reverse proxy (check `x-forwarded-for` header format in production)
- [ ] Test forgot-password flow: response time should be similar for existing and non-existing emails
- [ ] Verify static assets (`/public/*`) still load correctly after middleware reordering
- [ ] Check that expired sessions are cleaned up (inspect DB after 15+ minutes)

### Notes

All changes pass `tsc --noEmit` with zero errors. See `ISSUE-LOG.md` at the repo root for tracked non-critical issues.


Link to Devin session: https://app.devin.ai/sessions/1a570639f01d49e099f02716b9b25ef1
Requested by: @jumpkey